### PR TITLE
add netsupport

### DIFF
--- a/stalkerware_indicators.csv
+++ b/stalkerware_indicators.csv
@@ -912,3 +912,4 @@ domain,node5.theonespy.com,https://github.com/Te-k/stalkerware-indicators
 ipv4,85.13.218.229,https://github.com/Te-k/stalkerware-indicators
 ipv4,85.13.206.195,https://github.com/Te-k/stalkerware-indicators
 domain,viptrack.pro,original
+domain,geo.netsupportsoftware.com,original

--- a/stalkerware_urls.txt
+++ b/stalkerware_urls.txt
@@ -379,6 +379,7 @@ ftp.spyera.com
 ftp.spytector.com
 ftp.thetruthspy.com
 gattix.1337.cx
+geo.netsupportsoftware.com
 get-out.1337.cx
 get.snoopza.com
 git.reptilicus.net


### PR DESCRIPTION
is advertised for use in schools, is used in various malware campaigns, isn't detected by most AV due to having "legitimate uses"
not sure if this is the correct way to add a domain but hopefully i got it right
note that this is merely an indicator, blocking it doesn't actually stop the stalkerware